### PR TITLE
Изменение определения PlayerId на uuid

### DIFF
--- a/api.md
+++ b/api.md
@@ -558,8 +558,8 @@ OptionAnswer = {  # для заданий с ответом в виде выбо
 }
 
 Answer =
-  | CheckedTextAnswer  
-  | TextAnswer         
+  | CheckedTextAnswer
+  | TextAnswer
   | OptionAnswer
 
 TaskAnswer = {
@@ -656,7 +656,7 @@ TaskScoreboard = [] {
 TaskAnswers =
   # для заданий с ответом в виде текста с проверкой
   | [] {
-      value: CheckedWordAnswer  # значение ответа
+      value: CheckedTextAnswer  # значение ответа
       player-count: u16         # число игроков, которые ввели этот текст
       correct: bool             # является ли ответ верным
     }
@@ -669,7 +669,7 @@ TaskAnswers =
 
   # для заданий с ответом в виде текста
   | [] {
-      value: WordAnswer  # значение ответа
+      value: TextAnswer  # значение ответа
       votes: u16         # число голосов за ответ
     }
 

--- a/api.md
+++ b/api.md
@@ -355,7 +355,7 @@ Join = {
 
 ### 5.6. Сообщение Joined
 ```
-PlayerId = u32
+PlayerId = uuid
 SessionId = uuid
 
 GameDetails = {


### PR DESCRIPTION
Так как ид пользователей должны генерироваться случайно и непредсказуемо, большого смысла от того, что они `u32`, не было. На бэкэнде поэтому мы сразу использовали UUIDv4 аналогично другим идентификаторам (например, `ClientId`). Но я забыл поменять протокол, чтоб он отражал это решение.

Поэтому предлагаю поменять определение `PlayerId` в протоколе, чтобы он был `uuid`, как оно на бэкэнде. Особенно хочется услышать, насколько сильно это изменение заденет фронт.