### PR TITLE
add invite code to Joined

### DIFF
--- a/api.md
+++ b/api.md
@@ -371,7 +371,7 @@ Joined = {
   ref-id: MessageId
   player-id: PlayerId
   session-id: SessionId
-  invite-code?: InviteCode
+  invite-code: InviteCode | null
   max-players: u8
   game: GameDetails
 }

--- a/api.md
+++ b/api.md
@@ -371,6 +371,7 @@ Joined = {
   ref-id: MessageId
   player-id: PlayerId
   session-id: SessionId
+  invite-code?: InviteCode
   max-players: u8
   game: GameDetails
 }
@@ -387,6 +388,8 @@ Joined = {
 - `ref-id`: `msg-id` сообщения `Join`.
 - `player-id`: идентификатор игрока в пределах сессии.
 - `session-id`: идентификатор сессии.
+- `invite-code`: код для подключения к сессии. Присутствует, если сессия на этапе ожидания в лобби.
+- `max-players`: максимальное число игроков в сессии.
 - `game`: информация об игре.
 
 ### 5.7. Сообщение GameStatus


### PR DESCRIPTION
Так как подключение возможно по uuid сессии, он сохраняется на устройстве. При переподключении на этапе лобби нужно отобразить код на экране, а хранить его дополнительно не прикольно.